### PR TITLE
Bugfix: Update plugin version to fix bug about shadow jar

### DIFF
--- a/tower-backend/build.gradle
+++ b/tower-backend/build.gradle
@@ -12,7 +12,7 @@
 plugins {
     id "io.spring.dependency-management" version "1.0.6.RELEASE"
     id "groovy"
-    id "com.github.johnrengelman.shadow" version "4.0.2"
+    id "com.github.johnrengelman.shadow" version "5.1.0"
     id "application"
     id "com.google.cloud.tools.jib" version "0.9.9"
 }


### PR DESCRIPTION
Hello

This commit fixes a bug regarding the creation of shadow jar.

This project uses a gradle plugin to generate the shadow jar of the tower-backend project. However, the version 4.0.2 of this plugin has a bug regarding the creation of the shadow jar.

Specifically, the name of generated shadow jar is `tower-backend-19.08.0.jar`, which conflicts with the name of the jar generated by the naive `jar` task. So, there might be a race condition depending on the order in which gradle executes task `jar` and `shadowJar`.

Later versions of this plugin fixes this problem (See [here](https://imperceptiblethoughts.com/shadow/changes/#v5-1-0-2019-06-29)). Therefore this pull request update the version of the plugin so that the name of the generated shadow jar is now `tower-backend-19.08.0-all.jar` (i.e., it ends with the `-all.jar` suffix).

